### PR TITLE
fix: Add index.html as default Error page

### DIFF
--- a/infrastructure/cloud-formation.yaml
+++ b/infrastructure/cloud-formation.yaml
@@ -6,6 +6,7 @@ Resources:
       AccessControl: Private
       WebsiteConfiguration:
         IndexDocument: index.html
+        ErrorDocument: index.html
   WebsiteBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties: 
@@ -89,6 +90,12 @@ Resources:
           ViewerProtocolPolicy: redirect-to-https
         Enabled: true
         DefaultRootObject: index.html
+        # This allows us to serve everything in our React app through index
+        CustomErrorResponses: 
+          - ErrorCode: 403
+            ErrorCachingMinTTL: 0
+            ResponseCode: 200
+            ResponsePagePath: /index.html
         ViewerCertificate:
           CloudFrontDefaultCertificate: true
 


### PR DESCRIPTION
S3 expects that the path requested exactly matches the path in the bucket, but with React Apps, we largely serve directly through the `index.html` file. This change makes the default error page in S3 `index.html`, as well as add it as the default error page for `403` responses from CloudFront, which returns 403 rather than 404 on non-existing paths